### PR TITLE
对比图RAG索引构建实现

### DIFF
--- a/GraphRAG_Implementation_Analysis.md
+++ b/GraphRAG_Implementation_Analysis.md
@@ -1,0 +1,275 @@
+# GraphRAG实现对比分析
+## JayLZhou/GraphRAG vs graph_rag_index_construction
+
+### 概述
+
+本文档对比分析了两个GraphRAG实现：
+1. **JayLZhou/GraphRAG**: 基于论文《In-depth Analysis of Graph-based RAG in a Unified Framework》的统一框架实现
+2. **graph_rag_index_construction**: 专注于索引构建方法的实现
+
+---
+
+## 1. 架构设计对比
+
+### JayLZhou/GraphRAG 架构
+- **统一框架设计**: 实现了16种检索算子的模块化组合
+- **多方法支持**: 支持10种不同的GraphRAG方法（RAPTOR, LightRAG, MS GraphRAG等）
+- **分层架构**:
+  ```
+  Core/
+  ├── GraphRAG.py (主控制器)
+  ├── Graph/ (图构建)
+  ├── Index/ (索引系统)
+  ├── Retriever/ (检索器)
+  ├── Query/ (查询系统)
+  ├── Community/ (社区检测)
+  └── Storage/ (存储系统)
+  ```
+
+### graph_rag_index_construction 架构
+- **索引专精设计**: 专注于三大类索引构建方法
+- **模块化索引**: 
+  ```
+  ├── node_index/ (节点索引)
+  ├── relationship_index/ (关系索引)
+  ├── community_index/ (社区索引)
+  └── utils/ (工具函数)
+  ```
+
+---
+
+## 2. 核心功能对比
+
+### 2.1 图构建方式
+
+#### JayLZhou/GraphRAG
+- **5种图类型支持**:
+  - Chunk Tree: 文档树结构
+  - Passage Graph: 段落关系图
+  - KG: 知识图谱（三元组）
+  - TKG: 文本知识图谱（实体描述）
+  - RKG: 富知识图谱（关系关键词）
+
+#### graph_rag_index_construction
+- **4种节点索引**:
+  - Entity-based: 基于实体
+  - Document-based: 基于文档
+  - Concept-based: 基于概念
+  - Hierarchical: 分层结构
+
+### 2.2 检索算子系统
+
+#### JayLZhou/GraphRAG - 16种算子
+**实体算子 (7种)**:
+- VDB: 向量数据库检索
+- RelNode: 关系节点提取
+- PPR: 个性化PageRank
+- Agent: LLM智能实体发现
+- Onehop: 一跳邻居
+- Link: 实体链接
+- TF-IDF: 词频-逆文档频率
+
+**关系算子 (4种)**:
+- VDB: 向量关系检索
+- Onehop: 一跳关系
+- Aggregator: 关系聚合
+- Agent: LLM关系发现
+
+**文本块算子 (3种)**:
+- Aggregator: 聚合选择
+- FromRel: 关系文本提取
+- Occurrence: 共现排序
+
+**子图算子 (3种)**:
+- KhopPath: K跳路径
+- Steiner: 斯坦纳树
+- AgentPath: LLM路径发现
+
+**社区算子 (2种)**:
+- Entity: 实体社区
+- Layer: 分层社区
+
+#### graph_rag_index_construction
+- **关系索引 (4种)**:
+  - 语义关系索引
+  - 引用关系索引
+  - 共现关系索引
+  - 时序关系索引
+
+- **社区索引 (4种)**:
+  - Leiden算法
+  - Louvain算法
+  - 分层社区
+  - 动态社区
+
+---
+
+## 3. 技术实现对比
+
+### 3.1 配置系统
+
+#### JayLZhou/GraphRAG
+```yaml
+# 统一配置文件支持
+graph:
+  graph_type: rkg_graph
+  enable_edge_keywords: True
+  enable_entity_description: True
+  
+retriever:
+  query_type: basic
+  top_k_entity_for_ppr: 8
+  damping: 0.1
+  
+query:
+  enable_hybrid_query: True
+  retrieve_top_k: 20
+```
+
+#### graph_rag_index_construction
+```python
+# 程序化配置
+entity_index = EntityNodeIndex(
+    embedding_model="all-MiniLM-L6-v2",
+    similarity_threshold=0.7,
+    spacy_model="en_core_web_sm"
+)
+```
+
+### 3.2 存储系统
+
+#### JayLZhou/GraphRAG
+- **命名空间管理**: 工作区概念
+- **多存储后端**: 支持向量数据库、图存储
+- **持久化**: PickleBlobStorage等
+
+#### graph_rag_index_construction
+- **简单存储**: 基于文件系统
+- **统一接口**: save_index/load_index
+
+---
+
+## 4. 查询能力对比
+
+### JayLZhou/GraphRAG
+- **多查询类型**: 支持10种不同查询方法
+- **全局/局部搜索**: 
+  - 全局: 社区级别的宏观分析
+  - 局部: 实体级别的精准查询
+- **混合查询**: 结合多种检索策略
+
+### graph_rag_index_construction
+- **特定查询**: 针对索引类型的专门查询
+- **相似度搜索**: 基于嵌入的相似度计算
+- **社区查询**: 基于社区结构的信息检索
+
+---
+
+## 5. 优势与局限性分析
+
+### JayLZhou/GraphRAG 优势
+1. **统一框架**: 16种算子可自由组合，支持创新方法
+2. **方法覆盖**: 实现了主流的10种GraphRAG方法
+3. **工程完善**: 完整的配置、存储、评估系统
+4. **扩展性强**: 模块化设计便于扩展新方法
+5. **理论支撑**: 基于论文的系统性分类
+
+### JayLZhou/GraphRAG 局限性
+1. **复杂度高**: 学习曲线陡峭
+2. **资源需求**: 需要较多计算资源
+3. **配置复杂**: 参数众多，调优困难
+
+### graph_rag_index_construction 优势
+1. **专业专精**: 索引构建方法深入且完善
+2. **易于理解**: API设计简洁直观
+3. **轻量级**: 资源需求相对较少
+4. **文档完善**: 中文文档详细，示例丰富
+5. **实用性强**: 针对具体应用场景优化
+
+### graph_rag_index_construction 局限性
+1. **范围有限**: 仅覆盖索引构建部分
+2. **方法单一**: 不支持多种GraphRAG变体
+3. **查询能力**: 相对简单的查询功能
+
+---
+
+## 6. 适用场景分析
+
+### JayLZhou/GraphRAG 适用场景
+- **研究环境**: 需要对比多种GraphRAG方法
+- **大规模应用**: 处理复杂的企业级数据
+- **方法创新**: 基于算子组合开发新方法
+- **性能评估**: 需要系统性评估不同方法
+
+### graph_rag_index_construction 适用场景
+- **快速原型**: 快速构建GraphRAG索引
+- **特定需求**: 专注索引构建的应用
+- **学习研究**: 理解GraphRAG索引原理
+- **轻量部署**: 资源受限的环境
+
+---
+
+## 7. 技术栈对比
+
+### JayLZhou/GraphRAG
+```python
+# 核心依赖
+- pydantic: 配置管理
+- networkx: 图操作
+- tiktoken: Token处理
+- sentence-transformers: 文本嵌入
+- asyncio: 异步处理
+```
+
+### graph_rag_index_construction
+```python
+# 核心依赖
+- networkx: 图操作
+- scikit-learn: 机器学习
+- sentence-transformers: 文本嵌入
+- spacy: 自然语言处理
+- leidenalg/louvain: 社区检测
+```
+
+---
+
+## 8. 性能对比
+
+### 构建效率
+- **JayLZhou/GraphRAG**: 支持异步处理，可处理大规模数据
+- **graph_rag_index_construction**: 同步处理，适合中小规模数据
+
+### 查询性能
+- **JayLZhou/GraphRAG**: 多级缓存，优化的检索算法
+- **graph_rag_index_construction**: 基于索引的快速检索
+
+### 内存使用
+- **JayLZhou/GraphRAG**: 较高内存需求，支持分布式
+- **graph_rag_index_construction**: 内存友好，单机部署
+
+---
+
+## 9. 发展趋势与建议
+
+### 技术发展方向
+1. **算子标准化**: JayLZhou/GraphRAG的算子分类方法有望成为标准
+2. **混合架构**: 结合两者优势的混合架构
+3. **云原生**: 支持容器化和微服务架构
+4. **多模态**: 扩展到图像、音频等多模态数据
+
+### 选择建议
+1. **研究用途**: 选择JayLZhou/GraphRAG
+2. **生产环境**: 根据具体需求选择
+3. **学习目的**: 推荐graph_rag_index_construction
+4. **创新开发**: JayLZhou/GraphRAG提供更好的基础
+
+---
+
+## 10. 结论
+
+两个实现各有特色：
+
+- **JayLZhou/GraphRAG**是一个完整的、理论驱动的GraphRAG框架，适合研究和大规模应用
+- **graph_rag_index_construction**是一个专精的、实用的索引构建工具，适合特定场景和快速开发
+
+选择哪个实现应基于具体需求、资源限制和技术栈考虑。对于希望深入理解GraphRAG的开发者，建议两者都进行学习和实践。


### PR DESCRIPTION
Add `GraphRAG` submodule and a detailed analysis document comparing it with `graph_rag_index_construction`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-28cc5b40-af0b-4b70-bc67-03a67c0eaff4) · [Cursor](https://cursor.com/background-agent?bcId=bc-28cc5b40-af0b-4b70-bc67-03a67c0eaff4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)